### PR TITLE
Improve segmented packet reading

### DIFF
--- a/lib/p2p/connection_handler.ex
+++ b/lib/p2p/connection_handler.ex
@@ -141,6 +141,7 @@ defmodule Elixium.P2P.ConnectionHandler do
         message = Message.read(data, session_key)
 
         Logger.info("Accepted message from #{peername}")
+        Logger.info("Time #{:os.system_time(:millisecond)}")
 
         # Send out the message to the parent of this process (a.k.a the pid that
         # was passed in when calling start/2)
@@ -153,6 +154,7 @@ defmodule Elixium.P2P.ConnectionHandler do
       # through TCP
       {type, data} ->
         Logger.info("Sending data to peer: #{peername}")
+        Logger.info("Time #{:os.system_time(:millisecond)}")
 
         case Message.build(type, data, session_key) do
           {:ok, m} -> Message.send(m, socket)

--- a/lib/p2p/connection_handler.ex
+++ b/lib/p2p/connection_handler.ex
@@ -138,14 +138,14 @@ defmodule Elixium.P2P.ConnectionHandler do
       # When receiving a message through TCP, send the data back to the parent
       # process so it can handle it however it wants
       {:tcp, _, data} ->
-        message = Message.read(data, session_key)
+        messages = Message.read(data, session_key, socket)
 
         Logger.info("Accepted message from #{peername}")
         Logger.info("Time #{:os.system_time(:millisecond)}")
 
-        # Send out the message to the parent of this process (a.k.a the pid that
+        # Send out the messages to the parent of this process (a.k.a the pid that
         # was passed in when calling start/2)
-        send(master_pid, message)
+        Enum.each(messages, &(send(master_pid, &1)))
       {:tcp_closed, _} ->
         Logger.info("Lost connection from peer: #{peername}. TCP closed")
         Process.exit(self(), :normal)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Elixium.Mixfile do
   def project do
     [
       app: :elixium_core,
-      version: "0.2.5",
+      version: "0.2.6",
       elixir: "~> 1.7",
       elixirc_paths: ["lib"],
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Adds functionality to properly read TCP packets that don't contain a full message (or that contain more than just one message)

Also changes block validation logic to ignore difficulty with which the block was mined, and use calculated difficulty instead