### PR TITLE
Smooth Token Emission

### DIFF
--- a/lib/constants.ex
+++ b/lib/constants.ex
@@ -1,0 +1,29 @@
+defmodule Elixium.Constants do
+
+  @moduledoc """
+    Contains constants and functions for calculating certain constants. Mainly
+    allows for pre-compile constant generation.
+  """
+
+  # Total amount of tokens that will ever exist.
+  @total_token_supply 1_000_000_000.0
+
+  # Block at which last block reward will be distributed. Logic behind this
+  # number is to have tokens distributed over X period of time. We're going for
+  # a total emission period of 10 years. 10 years at 2 minutes per block gives
+  # us this 2_628_000 number.
+  @block_at_full_emission 2_628_000
+
+  @doc """
+    Sigma of the block number @block_at_full_emission. Used in emission algorithm
+  """
+  def sigma_full_emission_blocks(0), do: 0
+  def sigma_full_emission_blocks(n) do
+    n + sigma_full_emission_blocks(n - 1)
+  end
+
+  def block_at_full_emission, do: @block_at_full_emission
+
+  def total_token_supply, do: @total_token_supply
+
+end

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -82,10 +82,10 @@ defmodule BlockTest do
   end
 
   test "can correctly calculate block reward" do
-    assert D.equal?(Block.calculate_block_reward(1), D.new(100))
-    assert D.equal?(Block.calculate_block_reward(200_000), D.new(50))
-    assert D.equal?(Block.calculate_block_reward(175_000), D.new(100))
-    assert D.equal?(Block.calculate_block_reward(3_000_000), D.new(0.0030517578125))
+    assert :gt == D.cmp(Block.calculate_block_reward(1), D.new(761))
+    assert :gt == D.cmp(Block.calculate_block_reward(200_000), D.new(703))
+    assert :gt == D.cmp(Block.calculate_block_reward(175_000), D.new(710))
+    assert D.equal?(Block.calculate_block_reward(3_000_000), D.new(0.0))
   end
 
   test "can calculate block fees" do


### PR DESCRIPTION
Satoshi's method of minting coins through block rewards and halving the reward at given intervals worked well for Bitcoin, but this method causes pre-defined mining breakpoints or 'epochs' where miners may get discouraged from mining when block rewards are halved yet blocks require the same computational energy to mine. 

In order to combat this, we'll use a weighted smooth emission algorithm similar to that of CryptoNote as a means of distributing tokens. Our emission algorithm emits a high block reward early on, in order to incentivize early adoption, and scales down over time. 

This emission algorithm allows us to specify the total number of tokens we want to exist, as well as a specific block by which we want all tokens to be distributed. The algorithm takes these values into consideration as it smoothly scales the block reward every block. 

Where x is total token supply, t is block at full emission, i is block index, and s is the sigma of the total_token_supply, the smooth emission algorithm  is as follows: 
```(x * max{0, t - i}) / s```

I've defined the total existing tokens to be 1 billion and have specified an emission period of 2,628,000 blocks (~ 10 years), but this is subject to change as we see fit.