### PR TITLE
Compressed addresses

### DIFF
--- a/lib/base58.ex
+++ b/lib/base58.ex
@@ -5,9 +5,16 @@ defmodule Base58 do
     Provides functionality for encoding and decoding in Base58
   """
 
+  @doc """
+    Encode a binary of arbitrary size into Base58 string
+  """
+  @spec encode(binary) :: String.t()
   def encode(data, hash \\ "")
 
   def encode(data, hash) when is_binary(data) do
+    # We encode the zeros here explicitly since any leading zeros would
+    # be stripped by the decode_unsigned/1 function and we would lose
+    # potentially valuable data
     encode_zeros(data) <> encode(:binary.decode_unsigned(data), hash)
   end
 
@@ -21,17 +28,23 @@ defmodule Base58 do
     |> encode(character <> hash)
   end
 
+  # Encodes zeros explicitly
   defp encode_zeros(data) do
     <<Enum.at(@alphabet, 0)>>
     |> String.duplicate(leading_zeros(data))
   end
 
+  # Returns a number representing how many leading zeros this data has
   defp leading_zeros(data) do
     data
     |> :binary.bin_to_list()
     |> Enum.find_index(&(&1 != 0))
   end
 
+  @doc """
+    Decode a Base58 encoded string into its binary representation
+  """
+  @spec decode(String.t()) :: binary
   def decode(dec, acc \\ 0)
 
   def decode("", acc), do: :binary.encode_unsigned(acc)

--- a/lib/base58.ex
+++ b/lib/base58.ex
@@ -1,6 +1,10 @@
 defmodule Base58 do
   @alphabet '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
+  @moduledoc """
+    Provides functionality for encoding and decoding in Base58
+  """
+
   def encode(data, hash \\ "")
 
   def encode(data, hash) when is_binary(data) do

--- a/lib/base58.ex
+++ b/lib/base58.ex
@@ -1,0 +1,38 @@
+defmodule Base58 do
+  @alphabet '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+  def encode(data, hash \\ "")
+
+  def encode(data, hash) when is_binary(data) do
+    encode_zeros(data) <> encode(:binary.decode_unsigned(data), hash)
+  end
+
+  def encode(0, hash), do: hash
+
+  def encode(data, hash) do
+    character = <<Enum.at(@alphabet, rem(data, 58))>>
+
+    data
+    |> div(58)
+    |> encode(character <> hash)
+  end
+
+  defp encode_zeros(data) do
+    <<Enum.at(@alphabet, 0)>>
+    |> String.duplicate(leading_zeros(data))
+  end
+
+  defp leading_zeros(data) do
+    data
+    |> :binary.bin_to_list()
+    |> Enum.find_index(&(&1 != 0))
+  end
+
+  def decode(dec, acc \\ 0)
+
+  def decode("", acc), do: :binary.encode_unsigned(acc)
+
+  def decode(<<char::utf8, rest::binary>>, acc) do
+    decode(rest, (acc * 58) + Enum.find_index(@alphabet, &(&1 == char)))
+  end
+end

--- a/lib/keypair.ex
+++ b/lib/keypair.ex
@@ -1,4 +1,8 @@
 defmodule Elixium.KeyPair do
+  alias Elixium.Utilities
+  use Bitwise
+  require Integer
+
   @algorithm :ecdh
   @sigtype :ecdsa
   @curve :secp256k1
@@ -35,8 +39,9 @@ defmodule Elixium.KeyPair do
   defp create_keyfile({public, private}) do
     if !File.dir?(".keys"), do: File.mkdir(".keys")
 
-    pub_hex = Base.encode16(public)
-    File.write(".keys/#{pub_hex}.key", private)
+    address = address_from_pubkey(public)
+
+    File.write(".keys/#{address}.key", private)
   end
 
   @spec sign(binary, String.t()) :: String.t()
@@ -48,4 +53,75 @@ defmodule Elixium.KeyPair do
   def verify_signature(public_key, signature, data) do
     :crypto.verify(@sigtype, @hashtype, data, signature, [public_key, @curve])
   end
+
+  def checksum(version, compressed_pubkey) do
+    <<check::bytes-size(4), _::bits>> = :crypto.hash(:sha256, version <> compressed_pubkey)
+
+    check
+  end
+
+  def address_from_pubkey(pubkey) do
+    version = Application.get_env(:elixium_core, :address_version)
+    compressed_pubkey = compress_pubkey(pubkey)
+
+    addr =
+      compressed_pubkey <> checksum(version, compressed_pubkey)
+      |> Base58.encode()
+
+    version <> addr
+  end
+
+  def compress_pubkey(<<4, x::bytes-size(32), y::bytes-size(32)>>) do
+    y_even =
+      y
+      |> :binary.decode_unsigned()
+      |> Integer.is_even()
+
+    prefix = if y_even, do: <<2>>, else: <<3>>
+
+    prefix <> x
+  end
+
+  def address_to_pubkey(address) do
+    version = Application.get_env(:elixium_core, :address_version)
+
+    <<key_version::bytes-size(3)>> <> addr = address
+    <<prefix::bytes-size(1), x::bytes-size(32), checksum::binary>> = Base58.decode(addr)
+
+    y = calculate_y_from_x(x, prefix)
+
+    <<4>> <> x <> y
+  end
+
+  # Adapted from stackoverflow answer
+  # https://stackoverflow.com/questions/43629265/deriving-an-ecdsa-uncompressed-public-key-from-a-compressed-one/43654055
+  defp calculate_y_from_x(x, prefix) do
+    p =
+      "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F"
+      |> Base.decode16!()
+      |> :binary.decode_unsigned()
+
+    y_square_root =
+      x
+      |> :crypto.mod_pow(3, p)
+      |> :binary.decode_unsigned()
+      |> Kernel.+(7)
+      |> mod(p)
+      |> :crypto.mod_pow(Integer.floor_div(p + 1, 4), p)
+      |> :binary.decode_unsigned
+
+    y =
+      if (prefix == <<2>> && (y_square_root &&& 1) != 0) || (prefix == <<3>> && ((y_square_root &&& 1) == 0)) do
+        mod(-y_square_root, p)
+      else
+        y_square_root
+      end
+
+    :binary.encode_unsigned(y)
+  end
+
+  # Erlang rem/2 is not the same as modulus. This is true modulus
+  defp mod(x, y) when x > 0, do: rem(x, y)
+  defp mod(x, y) when x < 0, do: rem(x + y, y)
+  defp mod(0, _y), do: 0
 end

--- a/mix.exs
+++ b/mix.exs
@@ -71,6 +71,8 @@ defmodule Elixium.Mixfile do
         # Url used to bootstrap node connections
         registry_url: 'https://registry.testnet.elixium.app/',
 
+        address_version: "EX0"
+
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Elixium.Mixfile do
         ghost_protocol_version: "v1.0",
 
         # Url used to bootstrap node connections
-        registry_url: 'https://registry.testnet.elixium.app/'
+        registry_url: 'https://registry.testnet.elixium.app/',
 
         address_version: "EX0"
 

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -38,26 +38,26 @@ defmodule BlockTest do
 
   test "can properly calculate target with integer difficulty" do
     difficulty0 =
-      0
-      |> Block.calculate_target()
-      |> :binary.encode_unsigned()
-      |> Base.encode16()
-
-    difficulty1 =
       1
       |> Block.calculate_target()
       |> :binary.encode_unsigned()
       |> Base.encode16()
 
+    difficulty1 =
+      100_000
+      |> Block.calculate_target()
+      |> :binary.encode_unsigned()
+      |> Base.encode16()
+
     difficulty2 =
-      2
+      1_000_000_000
       |> Block.calculate_target()
       |> :binary.encode_unsigned()
       |> Base.encode16()
 
     assert difficulty0 == "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-    assert difficulty1 == "0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-    assert difficulty2 == "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    assert difficulty1 == "A7C5AC471B4787FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    assert difficulty2 == "044B82FA09B5A53FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
   end
 
   test "can properly calculate target with float difficulty" do
@@ -79,9 +79,9 @@ defmodule BlockTest do
       |> :binary.encode_unsigned()
       |> Base.encode16()
 
-    assert difficulty0 == "0696B6E3238C7B7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-    assert difficulty1 == "1A2D8DDEF4082AFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-    assert difficulty2 == "92"
+    assert difficulty0 == "C1F07C1F07C1EFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    assert difficulty1 == "2585F625AAA801FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    assert difficulty2 == "041DA22928559B7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
   end
 
   test "can correctly calculate block reward" do

--- a/test/fixtures/chain.exs
+++ b/test/fixtures/chain.exs
@@ -1,5 +1,5 @@
 [
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "00000A23C3D541A44F575D09BC8D0D7080493AB295BCBC9F39229A8A6F1CDD29",
     index: 11,
@@ -26,7 +26,7 @@
     ],
     version: 1
   },
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "0000077E74627951E01EE76DDF7F7609788CFED573F4BFAB4D2D577545ED5FCC",
     index: 10,
@@ -53,7 +53,7 @@
     ],
     version: 1
   },
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
   difficulty: 5.0,
   hash: "00000709CCCFE4933CB2EDBCF2D2040B48916855097AEE018F82C9C20D5C415A",
   index: 9,
@@ -80,7 +80,7 @@
   ],
   version: 1
   },
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "00000B87D259EFD1D97E9252264685F651431D6CB5B3302B5D12A94F9B8AB10F",
     index: 8,
@@ -104,7 +104,7 @@
       }
     ],
   version: 1},
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "00000A7B65FFB5690B9D18A450E15265C49868766176FE17EDAE6C1F91FC90F1",
     index: 7,
@@ -131,7 +131,7 @@
     ],
     version: 1
   },
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "000005BB261D77C3915C447FE4B8D6E0C03047AB415D6D622160E086F749A93F",
     index: 6,
@@ -157,7 +157,7 @@
       }
     ],
   version: 1},
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "00000C99FBE9511060066941DC8A8A49EC4EAED020E4EFC77930D8F59A9DB1C9",
     index: 5,
@@ -183,7 +183,7 @@
       }
     ],
     version: 1},
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "00000D91F99E2DBEF709FFF478640D01080BC9A921DC426F18822127FE813941",
     index: 4,
@@ -210,7 +210,7 @@
     ],
     version: 1
   },
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "00000008662EB371A0D46A0E4C0C62F2ABB2386182DD2E98FAE79AE4DF24A783",
     index: 3,
@@ -237,7 +237,7 @@
     ],
     version: 1
   },
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "00000B741D6655E6EAC06223120A73664ED6AC5C5C3CCC071DF3244C92319A4D",
     index: 2,
@@ -263,7 +263,7 @@
       }
     ],
     version: 1},
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "00000010D18D813E736E086F72885B6252B7EE500979CAD144B2E285574DECE3",
     index: 1,
@@ -289,7 +289,7 @@
       }
     ],
     version: 1},
-  %Elixium.Blockchain.Block{
+  %Elixium.Block{
     difficulty: 5.0,
     hash: "1167800E1997A264D82868295BBE871757D241AD220D15372C58880F255C19C3",
     index: 0,

--- a/test/keypair_test.exs
+++ b/test/keypair_test.exs
@@ -29,4 +29,15 @@ defmodule KeyPairTest do
 
     assert KeyPair.verify_signature(pub, signature, data) == true
   end
+
+  test "can generate an address from keypair" do
+    {pub, _priv} = KeyPair.create_keypair()
+
+    address = KeyPair.address_from_pubkey(pub)
+
+    <<version::bytes-size(3), _rest::binary>> = address
+
+    assert version == "EX0"
+    assert pub == KeyPair.address_to_pubkey(address)
+  end
 end


### PR DESCRIPTION
Moves us to compressed addresses rather than using bare public key addresses. This saves bandwidth and storage of about 25 bytes per UTXO. We're also moving our address encoding from base64 to base58 in order to remove ambiguity between certain characters ("O" and "0" can be confusing in certain fonts).

The new address format is as follows:
1. 3 bytes containing the address version number ("EX0" as of right now)
2. 32 bytes containing the x-coordinate of the public key
3. 4 bytes containing a checksum of the public key + version number. This allows us to check for mistyped addresses.

Here's a visual example of the address difference (**note: these don't represent the same public key**):
Original: `BOTKThJoBJEZJn1t9k8RUJUnOpN0E2ynLsHRHB5h9v4acDgrdC5106N4KnFGsxni3CWvdyaZuahcr3cr7DNkl3A=`

New:  `EX08TQa45c7TKzvvvYUXTavi8TR1z7aHJjB5DCVfX2LRUNakcnwqD`

Functionality has been added to keypair.ex that allows generation of an address based on a public key, and retrieval of a public key based on an address.