### PR TITLE
Fixing Peer Connection Messages and Authentication

### DIFF
--- a/lib/p2p/authentication.ex
+++ b/lib/p2p/authentication.ex
@@ -62,7 +62,7 @@ defmodule Elixium.P2P.Authentication do
       public_value: public_value,
       identifier: identifier
     })
-    |> Message.send(peer)
+    |> Message.send(peer) |> IO.inspect
 
     %{public_value: peer_public_value} = Message.read(peer)
 

--- a/lib/p2p/authentication.ex
+++ b/lib/p2p/authentication.ex
@@ -62,7 +62,7 @@ defmodule Elixium.P2P.Authentication do
       public_value: public_value,
       identifier: identifier
     })
-    |> Message.send(peer) |> IO.inspect
+    |> Message.send(peer)
 
     %{public_value: peer_public_value} = Message.read(peer)
 

--- a/lib/p2p/ghost_protocol/message.ex
+++ b/lib/p2p/ghost_protocol/message.ex
@@ -55,7 +55,7 @@ defmodule Elixium.P2P.GhostProtocol.Message do
     if protocol == "Ghost" do
       {:ok, data} = :gen_tcp.recv(socket, need)
 
-      :erlang.binary_to_term(predata<>data)
+      :erlang.binary_to_term(predata <> data)
     else
       {:error, :invalid_protocol}
     end
@@ -76,7 +76,7 @@ defmodule Elixium.P2P.GhostProtocol.Message do
     {bytes_body, _} = Integer.parse(bytes)
     take_bytes = bytes_body + byte_size(header)
     need_bytes = take_bytes - byte_size(data)
-    IO.inspect(take_bytes, label: "Message Byte Size")
+
 
     # Sometimes we get a packet with incomplete data. Parse use the byte count
     # in the message header to determine how many bytes we're waiting for and
@@ -114,7 +114,7 @@ defmodule Elixium.P2P.GhostProtocol.Message do
   @spec send(binary, reference) :: :ok | any
   def send(message, socket) do
     case :gen_tcp.send(socket, message) do
-      :ok -> socket
+      :ok -> :ok
       err -> err
     end
   end

--- a/lib/p2p/ghost_protocol/message.ex
+++ b/lib/p2p/ghost_protocol/message.ex
@@ -50,12 +50,12 @@ defmodule Elixium.P2P.GhostProtocol.Message do
   """
   @spec read(reference) :: map | {:error, :invalid_protocol}
   def read(socket) do
-    {protocol, bytes} = parse_header(socket)
-
+    {protocol, bytes, predata} = parse_header(socket)
+    need = bytes - byte_size(predata)
     if protocol == "Ghost" do
-      {:ok, data} = :gen_tcp.recv(socket, bytes)
+      {:ok, data} = :gen_tcp.recv(socket, need)
 
-      :erlang.binary_to_term(data)
+      :erlang.binary_to_term(predata<>data)
     else
       {:error, :invalid_protocol}
     end
@@ -76,6 +76,7 @@ defmodule Elixium.P2P.GhostProtocol.Message do
     {bytes_body, _} = Integer.parse(bytes)
     take_bytes = bytes_body + byte_size(header)
     need_bytes = take_bytes - byte_size(data)
+    IO.inspect(take_bytes, label: "Message Byte Size")
 
     # Sometimes we get a packet with incomplete data. Parse use the byte count
     # in the message header to determine how many bytes we're waiting for and
@@ -113,7 +114,7 @@ defmodule Elixium.P2P.GhostProtocol.Message do
   @spec send(binary, reference) :: :ok | any
   def send(message, socket) do
     case :gen_tcp.send(socket, message) do
-      :ok -> :ok
+      :ok -> socket
       err -> err
     end
   end
@@ -152,10 +153,10 @@ defmodule Elixium.P2P.GhostProtocol.Message do
       # Will get "Ghost|00000000|v1.0|" from socket
       |> :gen_tcp.recv(20)
 
-    [protocol, bytes, version, _] = String.split(header, "|")
+    [protocol, bytes, version, predata] = String.split(header, "|")
     {bytes, _} = Integer.parse(bytes)
 
-    {protocol, bytes}
+    {protocol, bytes, predata}
   end
 
   @spec decrypt(bitstring, <<_::256>>) :: map

--- a/lib/p2p/peer.ex
+++ b/lib/p2p/peer.ex
@@ -97,7 +97,7 @@ defmodule Elixium.P2P.Peer do
   @spec fetch_peers_from_registry(integer) :: List
   defp fetch_peers_from_registry(port) do
     url = Application.get_env(:elixium_core, :registry_url)
-    IO.inspect url
+    
     case :httpc.request(url ++ '/' ++ Integer.to_charlist(port)) do
       {:ok, {{'HTTP/1.1', 200, 'OK'}, _headers, body}} ->
         peers =

--- a/lib/p2p/peer.ex
+++ b/lib/p2p/peer.ex
@@ -4,6 +4,8 @@ defmodule Elixium.P2P.Peer do
 
   @default_port 31_013
 
+
+
   @moduledoc """
     Contains functionality for communicating with other peers
   """
@@ -95,7 +97,7 @@ defmodule Elixium.P2P.Peer do
   @spec fetch_peers_from_registry(integer) :: List
   defp fetch_peers_from_registry(port) do
     url = Application.get_env(:elixium_core, :registry_url)
-
+    IO.inspect url
     case :httpc.request(url ++ '/' ++ Integer.to_charlist(port)) do
       {:ok, {{'HTTP/1.1', 200, 'OK'}, _headers, body}} ->
         peers =

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,8 @@ defmodule Elixium.Mixfile do
       description: description(),
       source_url: "https://github.com/elixium/elixium_core",
       homepage_url: "https://elixium.app",
-      package: package()
+      package: package(),
+      application: application()
     ]
   end
 
@@ -69,7 +70,7 @@ defmodule Elixium.Mixfile do
         ghost_protocol_version: "v1.0",
 
         # Url used to bootstrap node connections
-        registry_url: 'https://registry.testnet.elixium.app/',
+        registry_url: 'https://registry.testnet.elixium.app/'
 
       ]
     ]


### PR DESCRIPTION
Fixed the core so that miners now authenticate with the wallet
Fixed Message byte size so peers now authenticate