### PR TITLE
Peer distribution

### DIFF
--- a/lib/block.ex
+++ b/lib/block.ex
@@ -194,6 +194,7 @@ defmodule Elixium.Block do
   end
 
   def calculate_difficulty(block, blocks_to_weight) do
+
     retargeting_window = Application.get_env(:elixium_core, :retargeting_window)
     target_solvetime = Application.get_env(:elixium_core, :target_solvetime)
 

--- a/lib/p2p/connection_handler.ex
+++ b/lib/p2p/connection_handler.ex
@@ -177,21 +177,17 @@ defmodule Elixium.P2P.ConnectionHandler do
       # When receiving data from the parent process, send it to the network
       # through TCP
       {type, data} ->
-        Logger.info("Sending data to peer: #{peername}")
-        Logger.info("Time #{:os.system_time(:millisecond)}")
         if type == "PING" do
           Process.put(:last_ping_time, :os.system_time(:millisecond))
+        else
+          Logger.info("Sending data to peer: #{peername}")
+          Logger.info("Time #{:os.system_time(:millisecond)}")
         end
 
         case Message.build(type, data, session_key) do
           {:ok, m} -> Message.send(m, socket)
           :error -> Logger.error("MESSAGE NOT SENT: Invalid message data: expected map.")
         end
-      #{"PING", _} ->
-      #  Logger.info("Recieved sucessful PING from #{peername}")
-    #    send(peername, {"PONG", %{}})
-    #  {"PONG", _} ->
-    #    Logger.info("Recieved sucessful PONG from #{peername}")
       m ->
         Logger.warn("Received message we haven't accounted for. Skipping! Message: #{inspect m}")
     end

--- a/lib/p2p/connection_handler.ex
+++ b/lib/p2p/connection_handler.ex
@@ -133,6 +133,8 @@ defmodule Elixium.P2P.ConnectionHandler do
     # Tell the master pid that we have a new connection
     if conn_type == :outbound do
       send(master_pid, {:new_outbound_connection, self()})
+    else
+      send(master_pid, {:new_inbound_connection, self()})
     end
 
     handle_connection(socket, session_key, master_pid, oracle)

--- a/lib/p2p/host_availability/host_availability.ex
+++ b/lib/p2p/host_availability/host_availability.ex
@@ -37,5 +37,5 @@ defmodule Elixium.HostAvailability do
     {:noreply, state}
   end
 
-  def handle_info({:tcp, _, _} state), do: {:noreply, state} 
+  def handle_info({:tcp, _, _}, state), do: {:noreply, state} 
 end

--- a/lib/p2p/host_availability/host_availability.ex
+++ b/lib/p2p/host_availability/host_availability.ex
@@ -1,0 +1,38 @@
+defmodule Elixium.HostAvailability do
+  use GenServer
+  require IEx
+  require Logger
+
+  def start_link(_args) do
+    Logger.info("Starting Host Availability through Port 31014..")
+      {:ok, socket} = :gen_tcp.listen(31014, [:binary, active: false, reuseaddr: true])
+    GenServer.start_link(__MODULE__, socket, name: __MODULE__)
+  end
+
+  def init(socket) do
+    Process.send_after(self(), :start_accept, 1000)
+
+    {:ok, %{listen: socket}}
+  end
+
+  def start_accept do
+    GenServer.cast(__MODULE__, :start_accept)
+  end
+
+  def handle_info(:start_accept, state) do
+    Logger.info("Host Availability Listening")
+
+    {:ok, socket} = :gen_tcp.accept(state.listen)
+
+    state = Map.put(state, :socket, socket)
+    {:noreply, state}
+  end
+
+  def handle_info({:tcp, _, data}, state) do
+    Logger.info("Received Data from Host")
+    IO.inspect data
+    :gen_tcp.send(state.socket, :os.timestamp)
+    {:noreply, state}
+  end
+
+end

--- a/lib/p2p/host_availability/host_availability.ex
+++ b/lib/p2p/host_availability/host_availability.ex
@@ -5,7 +5,7 @@ defmodule Elixium.HostAvailability do
 
   def start_link(_args) do
     Logger.info("Starting Host Availability through Port 31014..")
-      {:ok, socket} = :gen_tcp.listen(31014, [:binary, active: false, reuseaddr: true])
+    {:ok, socket} = :gen_tcp.listen(31014, [:binary, active: true, reuseaddr: true])
     GenServer.start_link(__MODULE__, socket, name: __MODULE__)
   end
 
@@ -29,9 +29,14 @@ defmodule Elixium.HostAvailability do
   end
 
   def handle_info({:tcp, _, data}, state) do
-    Logger.info("Received Data from Host")
-    IO.inspect data
-    :gen_tcp.send(state.socket, :os.timestamp)
+    Logger.info("Received Data from Host: #{data}")
+
+    :gen_tcp.send(state.socket, "HELLO")
+    :gen_tcp.close(state.socket)
+
+    {:ok, socket} = :gen_tcp.accept(state.listen)
+
+    state = Map.put(state, :socket, socket)
     {:noreply, state}
   end
 

--- a/lib/p2p/host_availability/host_availability.ex
+++ b/lib/p2p/host_availability/host_availability.ex
@@ -27,7 +27,7 @@ defmodule Elixium.HostAvailability do
   def handle_info({:tcp, _, <<0>>}, state) do
     Logger.info("Received Data from Host ")
 
-    :gen_tcp.send(state.socket, "HELLO")
+    :gen_tcp.send(state.socket, <<1>>)
     :gen_tcp.close(state.socket)
 
     {:ok, socket} = :gen_tcp.accept(state.listen)

--- a/lib/p2p/host_availability/host_availability.ex
+++ b/lib/p2p/host_availability/host_availability.ex
@@ -28,6 +28,7 @@ defmodule Elixium.HostAvailability do
     Logger.info("Received Data from Host ")
 
     :gen_tcp.send(state.socket, <<1>>)
+    :timer.sleep(1000)
     :gen_tcp.close(state.socket)
 
     {:ok, socket} = :gen_tcp.accept(state.listen)
@@ -36,4 +37,5 @@ defmodule Elixium.HostAvailability do
     {:noreply, state}
   end
 
+  def handle_info({:tcp, _, _} state), do: {:noreply, state} 
 end

--- a/lib/p2p/host_availability/host_availability.ex
+++ b/lib/p2p/host_availability/host_availability.ex
@@ -4,7 +4,6 @@ defmodule Elixium.HostAvailability do
   require Logger
 
   def start_link(_args) do
-    Logger.info("Starting Host Availability through Port 31014..")
     {:ok, socket} = :gen_tcp.listen(31014, [:binary, active: true, reuseaddr: true])
     GenServer.start_link(__MODULE__, socket, name: __MODULE__)
   end
@@ -16,8 +15,6 @@ defmodule Elixium.HostAvailability do
   end
 
   def handle_info(:start_accept, state) do
-    Logger.info("Host Availability Listening")
-
     {:ok, socket} = :gen_tcp.accept(state.listen)
 
     state = Map.put(state, :socket, socket)
@@ -25,8 +22,6 @@ defmodule Elixium.HostAvailability do
   end
 
   def handle_info({:tcp, _, <<0>>}, state) do
-    Logger.info("Received Data from Host ")
-
     :gen_tcp.send(state.socket, <<1>>)
     :timer.sleep(1000)
     :gen_tcp.close(state.socket)
@@ -37,5 +32,5 @@ defmodule Elixium.HostAvailability do
     {:noreply, state}
   end
 
-  def handle_info({:tcp, _, _}, state), do: {:noreply, state} 
+  def handle_info({:tcp, _, _}, state), do: {:noreply, state}
 end

--- a/lib/p2p/host_availability/host_availability.ex
+++ b/lib/p2p/host_availability/host_availability.ex
@@ -15,10 +15,6 @@ defmodule Elixium.HostAvailability do
     {:ok, %{listen: socket}}
   end
 
-  def start_accept do
-    GenServer.cast(__MODULE__, :start_accept)
-  end
-
   def handle_info(:start_accept, state) do
     Logger.info("Host Availability Listening")
 
@@ -28,8 +24,8 @@ defmodule Elixium.HostAvailability do
     {:noreply, state}
   end
 
-  def handle_info({:tcp, _, data}, state) do
-    Logger.info("Received Data from Host: #{data}")
+  def handle_info({:tcp, _, <<0>>}, state) do
+    Logger.info("Received Data from Host ")
 
     :gen_tcp.send(state.socket, "HELLO")
     :gen_tcp.close(state.socket)

--- a/lib/p2p/host_availability/host_check.ex
+++ b/lib/p2p/host_availability/host_check.ex
@@ -1,0 +1,48 @@
+defmodule Elixium.HostCheck do
+  use GenServer
+  require IEx
+  require Logger
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init([]) do
+    Process.send_after(self(), :check_health, 1000)
+    {:ok, %{}}
+  end
+
+  def handle_info(:check_health, state) do
+
+    case GenServer.call(:"Elixir.Elixium.Store.PeerOracle", {:load_known_peers, []}) do
+      :not_found -> :ok
+      peers -> Enum.each(peers, &attempt_response/1)
+    end
+
+    Process.send_after(self(), :check_health, 600000)
+    {:noreply, state}
+  end
+
+  defp attempt_response({ip, _port}) do
+    with {:ok, socket} <- :gen_tcp.connect(ip, 31014, [:binary, active: true], 1000) do
+      :gen_tcp.send(socket, <<0>>)
+    end
+  end
+
+  def handle_info({:tcp_closed, _}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:tcp, socket, <<1>>}, state) do
+    #Shuffle List
+    {:ok, {add, _port}} = :inet.peername(socket)
+    ip =
+      add
+      |> :inet_parse.ntoa()
+
+    GenServer.call(:"Elixir.Elixium.Store.PeerOracle", {:reorder_peers, [ip]})
+    {:noreply, state}
+  end
+
+
+end

--- a/lib/p2p/host_availability/host_check.ex
+++ b/lib/p2p/host_availability/host_check.ex
@@ -44,6 +44,6 @@ defmodule Elixium.HostCheck do
     {:noreply, state}
   end
 
-  def handle_info({:tcp, _, _} state), do: {:noreply, state} 
+  def handle_info({:tcp, _, _}, state), do: {:noreply, state} 
 
 end

--- a/lib/p2p/host_availability/host_check.ex
+++ b/lib/p2p/host_availability/host_check.ex
@@ -44,5 +44,6 @@ defmodule Elixium.HostCheck do
     {:noreply, state}
   end
 
+  def handle_info({:tcp, _, _} state), do: {:noreply, state} 
 
 end

--- a/lib/p2p/host_availability/supervisor.ex
+++ b/lib/p2p/host_availability/supervisor.ex
@@ -2,7 +2,6 @@ defmodule Elixium.HostAvailability.Supervisor do
   use Supervisor
 
   def start_link() do
-    IO.puts "Within Startlink"
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 

--- a/lib/p2p/host_availability/supervisor.ex
+++ b/lib/p2p/host_availability/supervisor.ex
@@ -8,7 +8,8 @@ defmodule Elixium.HostAvailability.Supervisor do
 
   def init(_args) do
     children = [
-      Elixium.HostAvailability
+      Elixium.HostAvailability,
+      Elixium.HostCheck
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/p2p/host_availability/supervisor.ex
+++ b/lib/p2p/host_availability/supervisor.ex
@@ -1,0 +1,16 @@
+defmodule Elixium.HostAvailability.Supervisor do
+  use Supervisor
+
+  def start_link() do
+    IO.puts "Within Startlink"
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_args) do
+    children = [
+      Elixium.HostAvailability
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/p2p/peer.ex
+++ b/lib/p2p/peer.ex
@@ -24,6 +24,8 @@ defmodule Elixium.P2P.Peer do
     |> start_listener()
     |> generate_handlers(port, comm_pid)
     |> Supervisor.start_link(strategy: :one_for_one, name: :peer_supervisor, max_restarts: 20)
+
+    Elixium.HostAvailability.Supervisor.start_link() |> IO.inspect
   end
 
   @doc """
@@ -42,6 +44,7 @@ defmodule Elixium.P2P.Peer do
       end)
   end
 
+
   @doc """
     Broadcast a message to all peers
   """
@@ -49,6 +52,8 @@ defmodule Elixium.P2P.Peer do
   def gossip(type, message) do
     Enum.each(connected_handlers(), &(send(&1, {type, message})))
   end
+
+
 
   # Opens a socket listening on the given port
   defp start_listener(port) do

--- a/lib/p2p/peer.ex
+++ b/lib/p2p/peer.ex
@@ -25,7 +25,7 @@ defmodule Elixium.P2P.Peer do
     |> generate_handlers(port, comm_pid)
     |> Supervisor.start_link(strategy: :one_for_one, name: :peer_supervisor, max_restarts: 20)
 
-    Elixium.HostAvailability.Supervisor.start_link() |> IO.inspect
+    Elixium.HostAvailability.Supervisor.start_link()
   end
 
   @doc """

--- a/lib/p2p/peer.ex
+++ b/lib/p2p/peer.ex
@@ -44,7 +44,6 @@ defmodule Elixium.P2P.Peer do
       end)
   end
 
-
   @doc """
     Broadcast a message to all peers
   """

--- a/lib/store/peer.ex
+++ b/lib/store/peer.ex
@@ -36,6 +36,20 @@ defmodule Elixium.Store.Peer do
     end
   end
 
+  def reorder_peers(ip) do
+    IO.inspect(ip, label: "IP RAW")
+  
+    transact @store_dir do
+      fn ref ->
+        {:ok, peers} = Exleveldb.get(ref, "known_peers")
+        peers = :erlang.binary_to_term(peers) |> IO.inspect(label: "PEERS")
+        peer = Enum.find(peers, &(elem(&1, 0) == ip)) |> IO.inspect(label: "PEER")
+
+        Exleveldb.put(ref, "known_peers", :erlang.term_to_binary([peer | peers -- [peer]]))
+      end
+    end
+  end
+
   def save_self(identifier, password, ip) do
     transact @store_dir do
       &Exleveldb.put(&1, "self_#{ip}", :erlang.term_to_binary({identifier, password}))

--- a/lib/store/peer.ex
+++ b/lib/store/peer.ex
@@ -37,13 +37,11 @@ defmodule Elixium.Store.Peer do
   end
 
   def reorder_peers(ip) do
-    IO.inspect(ip, label: "IP RAW")
-  
     transact @store_dir do
       fn ref ->
         {:ok, peers} = Exleveldb.get(ref, "known_peers")
-        peers = :erlang.binary_to_term(peers) |> IO.inspect(label: "PEERS")
-        peer = Enum.find(peers, &(elem(&1, 0) == ip)) |> IO.inspect(label: "PEER")
+        peers = :erlang.binary_to_term(peers)
+        peer = Enum.find(peers, &(elem(&1, 0) == ip))
 
         Exleveldb.put(ref, "known_peers", :erlang.term_to_binary([peer | peers -- [peer]]))
       end

--- a/lib/store/peer.ex
+++ b/lib/store/peer.ex
@@ -29,6 +29,13 @@ defmodule Elixium.Store.Peer do
     end
   end
 
+  #Removes peer if no response was heard
+  def remove_peer(identifier) do
+    transact @store_dir do
+      &Exleveldb.delete(&1, identifier)
+    end
+  end
+
   def save_self(identifier, password, ip) do
     transact @store_dir do
       &Exleveldb.put(&1, "self_#{ip}", :erlang.term_to_binary({identifier, password}))
@@ -55,7 +62,7 @@ defmodule Elixium.Store.Peer do
             peers =
               [peer | :erlang.binary_to_term(peers)]
               |> Enum.uniq()
-              
+
             Exleveldb.put(ref, "known_peers", :erlang.term_to_binary(peers))
 
           :not_found ->


### PR DESCRIPTION
In this PR, Matthew and I added:

- A mechanism for pinging peers
- Every known peer gets pinged once an hour and peers are reorganized based on their response, eventually peers that have been offline for a long time will go to the bottom of our list
- Peer sharing functionality -- when connected to one of your peers, you ask them for a list of their top 8 peers and add them to your list so they can serve as an option for connection later
