### PR TITLE
Shuffle Peer Connection Fix

### DIFF
--- a/lib/p2p/host_availability/host_check.ex
+++ b/lib/p2p/host_availability/host_check.ex
@@ -35,15 +35,16 @@ defmodule Elixium.HostCheck do
 
   def handle_info({:tcp, socket, <<1>>}, state) do
     #Shuffle List
-    {:ok, {add, _port}} = :inet.peername(socket)
-    ip =
-      add
-      |> :inet_parse.ntoa()
-
-    GenServer.call(:"Elixir.Elixium.Store.PeerOracle", {:reorder_peers, [ip]})
-    {:noreply, state}
+    case :inet.peername(socket) do
+       {:error, :einval} -> Logger.error("ERROR IN PING SHUFFLE")
+       {:ok, {add, _port}} ->
+         ip =
+           add
+           |> :inet_parse.ntoa()
+           Oracle.inquire(:"Elixir.Elixium.Store.PeerOracle", {:reorder_peers, [ip]})
+    end
   end
 
-  def handle_info({:tcp, _, _}, state), do: {:noreply, state} 
+  def handle_info({:tcp, _, _}, state), do: {:noreply, state}
 
 end


### PR DESCRIPTION
Catches `eaadr` Errors With the Peer Shuffling Function