### PR TITLE
Fix transaction security issues

### DIFF
--- a/lib/keypair.ex
+++ b/lib/keypair.ex
@@ -7,7 +7,7 @@ defmodule Elixium.KeyPair do
   @sigtype :ecdsa
   @curve :secp256k1
   @hashtype :sha256
-  
+
   @moduledoc """
     All the functions responsible for creating keypairs and using them to sign
     data / verify signatures
@@ -34,10 +34,6 @@ defmodule Elixium.KeyPair do
     {:ok, private} = File.read(path)
     :crypto.generate_key(@algorithm, @curve, private)
   end
-
-
-
-
 
   @spec create_keyfile(tuple) :: :ok | {:error, any}
   defp create_keyfile({public, private}) do

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -11,6 +11,7 @@ defmodule Elixium.Transaction do
   defstruct id: nil,
             inputs: [],
             outputs: [],
+            sigs: [],
             # Most transactions will be pay-to-public-key
             txtype: "P2PK"
 
@@ -88,5 +89,15 @@ defmodule Elixium.Transaction do
     sanitized_transaction
     |> Map.put(:inputs, sanitized_inputs)
     |> Map.put(:outputs, sanitized_outputs)
+  end
+
+  @doc """
+    Returns the data that a signer of the transaction needs to sign
+  """
+  @spec signing_digest(Transaction) :: binary
+  def signing_digest(%{inputs: inputs, outputs: outputs, id: id, txtype: txtype}) do
+    digest = :erlang.term_to_binary(inputs) <> :erlang.term_to_binary(outputs) <> id <> txtype
+
+    :crypto.hash(:sha256, digest)
   end
 end

--- a/lib/utxo.ex
+++ b/lib/utxo.ex
@@ -1,7 +1,7 @@
 defmodule Elixium.Utxo do
   alias Elixium.Utxo
 
-  defstruct [:addr, :amount, :txoid, :signature]
+  defstruct [:addr, :amount, :txoid]
 
   @doc """
     Takes in a utxo received from a peer which may have malicious or extra

--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -6,6 +6,7 @@ defmodule Elixium.Validator do
   alias Elixium.Store.Utxo, as: UtxoStore
   alias Elixium.Utxo
   alias Elixium.BlockEncoder
+  alias Elixium.Transaction
   alias Decimal, as: D
 
   @moduledoc """
@@ -93,27 +94,52 @@ defmodule Elixium.Validator do
 
   @doc """
     Checks if a transaction is valid. A transaction is considered valid if
-    1) all of its inputs are currently in our UTXO pool and 2) all of its inputs
-    have a valid signature, signed by the owner of the private key associated to
-    the input (the addr). pool_check is a function which tests whether or not a
+    1) all of its inputs are currently in our UTXO pool and 2) all addresses
+    listed in the inputs have a corresponding signature in the sig set of the
+    transaction. pool_check is a function which tests whether or not a
     given input is in a pool (this is mostly used in the case of a fork), and
     this function must return a boolean.
   """
   @spec valid_transaction?(Transaction, function) :: boolean
-  def valid_transaction?(%{inputs: inputs}, pool_check \\ &UtxoStore.in_pool?/1) do
-    inputs
-    |> Enum.map(fn input ->
-      # Ensure that this input is in our UTXO pool
-      if pool_check.(input) do
-        pub = KeyPair.address_to_pubkey(input.addr)
-        {:ok, sig} = Base.decode16(input.signature)
-        # Check if this UTXO has a valid signature
-        KeyPair.verify_signature(pub, sig, Utxo.hash(input))
-      else
-        false
-      end
+  def valid_transaction?(transaction, pool_check \\ &UtxoStore.in_pool?/1) do
+    with true <- Enum.all?(transaction.inputs, & pool_check.(&1)),
+         true <- tx_addr_match?(transaction),
+         true <- tx_sigs_valid?(transaction),
+         true <- outputs_dont_exceed_inputs?(transaction) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  @spec tx_addr_match(Transaction) :: boolean
+  defp tx_addr_match?(transaction) do
+    signed_addresses = Enum.map(transaction.sigs, fn {addr, _sig} -> addr end)
+
+    # Check that all addresses in the inputs are also part of the signature set
+    transaction.inputs
+    |> Enum.map(& &1.addr)
+    |> Enum.uniq()
+    |> Enum.all?(& Enum.member?(signed_addresses, &1))
+  end
+
+  @spec tx_sigs_valid?(Transaction) :: boolean
+  defp tx_sigs_valid?(transaction) do
+    Enum.all?(transaction.sigs, fn {addr, sig} ->
+      pub = KeyPair.address_to_pubkey(addr)
+
+      transaction_digest = Transaction.signing_digest(transaction)
+
+      KeyPair.verify_signature(pub, sig, transaction_digest)
     end)
-    |> Enum.all?()
+  end
+
+  @spec outputs_dont_exceed_inputs?(Transaction) :: boolean
+  defp outputs_dont_exceed_inputs?(transaction) do
+    input_total = Transactions.sum_inputs(transaction.inputs)
+    output_total = Transactions.sum_inputs(transaction.outputs)
+
+    D.cmp(output_total, input_total) != :gt
   end
 
   @spec valid_transactions?(Block, function) :: :ok | {:error, :invalid_inputs}

--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -112,7 +112,7 @@ defmodule Elixium.Validator do
     end
   end
 
-  @spec tx_addr_match(Transaction) :: boolean
+  @spec tx_addr_match?(Transaction) :: boolean
   defp tx_addr_match?(transaction) do
     signed_addresses = Enum.map(transaction.sigs, fn {addr, _sig} -> addr end)
 
@@ -136,8 +136,8 @@ defmodule Elixium.Validator do
 
   @spec outputs_dont_exceed_inputs?(Transaction) :: boolean
   defp outputs_dont_exceed_inputs?(transaction) do
-    input_total = Transactions.sum_inputs(transaction.inputs)
-    output_total = Transactions.sum_inputs(transaction.outputs)
+    input_total = Transaction.sum_inputs(transaction.inputs)
+    output_total = Transaction.sum_inputs(transaction.outputs)
 
     D.cmp(output_total, input_total) != :gt
   end


### PR DESCRIPTION
Fixes #40 . Included in this PR:
- Fixed an issue where the outputs of a transaction could specify any amount and, and exceed the inputs of a transaction
- Fixed an issue where outputs could be hijacked by a relayer (sigs have been moved from the utxo level to the transaction level)
- New transaction validation logic -- A transaction must have a signature from each of the unique addresses in the transactions inputs
- New coinbase transaction validation logic -- Only allow one coinbase per block