### PR TITLE
Replace decimal based representation of UTXO amount with integer based Ions

### DIFF
--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -6,7 +6,6 @@ defmodule Elixium.Validator do
   alias Elixium.BlockEncoder
   alias Elixium.Store.Oracle
   alias Elixium.Transaction
-  alias Decimal, as: D
 
   @moduledoc """
     Responsible for implementing the consensus rules to all blocks and transactions
@@ -143,7 +142,7 @@ defmodule Elixium.Validator do
          :ok <- passes_pool_check?(transaction, pool_check),
          :ok <- tx_addr_match?(transaction),
          :ok <- tx_sigs_valid?(transaction),
-         :ok <- utxo_amount_decimal?(transaction),
+         :ok <- utxo_amount_integer?(transaction),
          :ok <- outputs_dont_exceed_inputs?(transaction) do
       :ok
     else
@@ -199,21 +198,22 @@ defmodule Elixium.Validator do
     if all?, do: :ok, else: {:error, :invalid_tx_sig}
   end
 
-  @spec utxo_amount_decimal?(Transaction) :: :ok | {:error, :utxo_amount_not_decimal}
-  def utxo_amount_decimal?(transaction) do
-    if Enum.all?(transaction.inputs ++ transaction.outputs, & D.decimal?(&1.amount)) do
+  @spec utxo_amount_integer?(Transaction) :: :ok | {:error, :utxo_amount_not_integer}
+  def utxo_amount_integer?(transaction) do
+    if Enum.all?(transaction.inputs ++ transaction.outputs, & is_integer(&1.amount)) do
       :ok
     else
-      {:error, :utxo_amount_not_decimal}
+      IO.inspect transaction
+      {:error, :utxo_amount_not_integer}
     end
   end
 
-  @spec outputs_dont_exceed_inputs?(Transaction) :: :ok | {:error, {:outputs_exceed_inputs, Decimal.t(), Decimal.t()}}
+  @spec outputs_dont_exceed_inputs?(Transaction) :: :ok | {:error, {:outputs_exceed_inputs, integer, integer}}
   defp outputs_dont_exceed_inputs?(transaction) do
     input_total = Transaction.sum_inputs(transaction.inputs)
     output_total = Transaction.sum_inputs(transaction.outputs)
 
-    if D.cmp(output_total, input_total) != :gt do
+    if output_total <= input_total do
       :ok
     else
       {:error, {:outputs_exceed_inputs, output_total, input_total}}
@@ -230,7 +230,7 @@ defmodule Elixium.Validator do
   defp is_coinbase?(%{txtype: "COINBASE"}), do: :ok
   defp is_coinbase?(tx), do: {:error, {:not_coinbase, tx.txtype}}
 
-  @spec appropriate_coinbase_output?(list, number) :: :ok | {:error, :invalid_coinbase}
+  @spec appropriate_coinbase_output?(list, number) :: :ok | {:error, :invalid_coinbase, integer, integer, integer}
   defp appropriate_coinbase_output?([coinbase | transactions], block_index) do
     total_fees = Block.total_block_fees(transactions)
 
@@ -241,7 +241,7 @@ defmodule Elixium.Validator do
 
     amount = hd(coinbase.outputs).amount
 
-    if D.equal?(D.add(total_fees, reward), amount) do
+    if total_fees + reward == amount do
       :ok
     else
       {:error, {:invalid_coinbase, total_fees, reward, amount}}

--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -203,7 +203,6 @@ defmodule Elixium.Validator do
     if Enum.all?(transaction.inputs ++ transaction.outputs, & is_integer(&1.amount)) do
       :ok
     else
-      IO.inspect transaction
       {:error, :utxo_amount_not_integer}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,6 @@ defmodule Elixium.Mixfile do
       {:keccakf1600, "~> 2.0.0"},
       {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
-      {:decimal, "~> 1.0"},
       {:strap, "~> 0.1.1"},
       {:jason, "~> 1.0"}
     ]

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -1,7 +1,6 @@
 defmodule BlockTest do
   alias Elixium.Block
   alias Elixium.Transaction
-  alias Decimal, as: D
   use ExUnit.Case, async: false
 
   test "can create a genesis block" do
@@ -82,35 +81,35 @@ defmodule BlockTest do
   end
 
   test "can correctly calculate block reward" do
-    assert :gt == D.cmp(Block.calculate_block_reward(1), D.new(761))
-    assert :gt == D.cmp(Block.calculate_block_reward(200_000), D.new(703))
-    assert :gt == D.cmp(Block.calculate_block_reward(175_000), D.new(710))
-    assert D.equal?(Block.calculate_block_reward(3_000_000), D.from_float(0.0))
+    assert Block.calculate_block_reward(1) == 7610344284
+    assert Block.calculate_block_reward(200_000) == 7031173118
+    assert Block.calculate_block_reward(175_000) == 7103569876
+    assert Block.calculate_block_reward(3_000_000) == 0
   end
 
   test "can calculate block fees" do
     transactions = [
       %Transaction{
         inputs: [
-          %{txoid: "sometxoid", amount: D.new(21)},
-          %{txoid: "othertxoid", amount: D.new(123.23)}
+          %{txoid: "sometxoid", amount: 210_000_000},
+          %{txoid: "othertxoid", amount: 1232300000}
         ],
         outputs: [
-          %{txoid: "atxoid", amount: D.new(112)}
+          %{txoid: "atxoid", amount: 1_120_000_000}
         ]
       },
       %Transaction{
         inputs: [
-          %{txoid: "bleh", amount: D.new(1)},
-          %{txoid: "meh", amount: D.new(13)}
+          %{txoid: "bleh", amount: 10_000_000},
+          %{txoid: "meh", amount: 130_000_000}
         ],
         outputs: [
-          %{txoid: "atxoid", amount: D.new(14)}
+          %{txoid: "atxoid", amount: 140_000_000}
         ]
       }
     ]
 
     total_fees = Block.total_block_fees(transactions)
-    refute D.equal?(total_fees, D.new(158.23))
+    refute total_fees == 1_582_300_000
   end
 end

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -81,9 +81,9 @@ defmodule BlockTest do
   end
 
   test "can correctly calculate block reward" do
-    assert Block.calculate_block_reward(1) == 7610344284
-    assert Block.calculate_block_reward(200_000) == 7031173118
-    assert Block.calculate_block_reward(175_000) == 7103569876
+    assert Block.calculate_block_reward(1) == 7_610_344_284
+    assert Block.calculate_block_reward(200_000) == 7_031_173_118
+    assert Block.calculate_block_reward(175_000) == 7_103_569_876
     assert Block.calculate_block_reward(3_000_000) == 0
   end
 
@@ -92,7 +92,7 @@ defmodule BlockTest do
       %Transaction{
         inputs: [
           %{txoid: "sometxoid", amount: 210_000_000},
-          %{txoid: "othertxoid", amount: 1232300000}
+          %{txoid: "othertxoid", amount: 1_232_300_000}
         ],
         outputs: [
           %{txoid: "atxoid", amount: 1_120_000_000}

--- a/test/blockchain_test.exs
+++ b/test/blockchain_test.exs
@@ -4,7 +4,6 @@ defmodule BlockchainTest do
   alias Elixium.Store.Utxo
   alias Elixium.Transaction
   alias Elixium.Utilities
-  alias Decimal, as: D
   use ExUnit.Case, async: false
 
   setup _ do
@@ -21,7 +20,7 @@ defmodule BlockchainTest do
     block = Block.initialize()
     block = Map.put(block, :transactions, [])
     index = :binary.decode_unsigned(block.index)
-    coin_base = D.add(Block.calculate_block_reward(index), Block.total_block_fees(block.transactions))
+    coin_base = Block.calculate_block_reward(index) + Block.total_block_fees(block.transactions)
     coinbase = Transaction.generate_coinbase(coin_base, "EX06BQPcYtf5QQdY3Tg1D8V26dcL2xSiLQwPQ7gfosoza2oRjb23L")
     transactions = [coinbase | block.transactions]
     txdigests = Enum.map(transactions, &:erlang.term_to_binary/1)
@@ -45,7 +44,7 @@ defmodule BlockchainTest do
     block = Block.initialize()
     block = Map.put(block, :transactions, [])
     index = :binary.decode_unsigned(block.index)
-    coin_base = D.add(Block.calculate_block_reward(index), Block.total_block_fees(block.transactions))
+    coin_base = Block.calculate_block_reward(index) + Block.total_block_fees(block.transactions)
     coinbase = Transaction.generate_coinbase(coin_base, "EX06BQPcYtf5QQdY3Tg1D8V26dcL2xSiLQwPQ7gfosoza2oRjb23L")
     transactions = [coinbase | block.transactions]
     txdigests = Enum.map(transactions, &:erlang.term_to_binary/1)
@@ -66,7 +65,7 @@ defmodule BlockchainTest do
       |> Block.initialize()
     block = Map.put(block, :transactions, [])
     index = :binary.decode_unsigned(block.index)
-    coin_base = D.add(Block.calculate_block_reward(index), Block.total_block_fees(block.transactions))
+    coin_base = Block.calculate_block_reward(index) + Block.total_block_fees(block.transactions)
     coinbase = Transaction.generate_coinbase(coin_base, "EX06BQPcYtf5QQdY3Tg1D8V26dcL2xSiLQwPQ7gfosoza2oRjb23L")
     transactions = [coinbase | block.transactions]
     txdigests = Enum.map(transactions, &:erlang.term_to_binary/1)


### PR DESCRIPTION
Solves #91. Removes Decimal as a dependency, fixes tests, and uses scale of 1/10,000,000 for Elixir/Ion. UTXO amounts are only stored as ions. 

Due to the shift from decimal to ions, we lose some precision when calculating block rewards, since we now have precision to 7 decimal places with ions, whereas Decimal was able to have a much higher precision. This isn't a big issue (tradeoff is that ions can be represented with fewer bits), but it does mean that our way of calculating block rewards was skewed, meaning that the total supply of elixir tokens was shifted down to 999999999.8686 rather than 1 billion. To keep the amount of total tokens as close to 1 billion as possible, I shifted the emission algorithm a bit:

> Where x is total token supply, t is block at full emission, i is block index,
> and s is the sigma of the total_token_supply, the Smooth emission algorithm
> is as follows: Round(((x * 10,000,000) * max{0, t - i}) / s) (+1 if i % 172 = 0)

This brings us much closer to 1 billion total token supply, with a total of `1,000,000,000.0000028`

Wallet, node, and miner need to be updated accordingly.