### PR TITLE
For Issue #93 - Update protocol to only send block headers 

### DIFF
--- a/lib/store/ledger.ex
+++ b/lib/store/ledger.ex
@@ -69,6 +69,7 @@ defmodule Elixium.Store.Ledger do
         fn ref ->
           ref
           |> Exleveldb.map(fn {_, block} -> BlockEncoder.decode(block) end)
+          |> Enum.map(fn block -> Elixium.Block.header(block) end)
           |> Enum.sort_by(& &1.index, &>=/2)
         end
       end


### PR DESCRIPTION
I've changed the retrieve_ledger/1 to return a list of block headers instead.